### PR TITLE
Fix retrieving VM IP address if there are multiple leases for the same VM

### DIFF
--- a/lib/vagrant-libvirt/action/read_ssh_info.rb
+++ b/lib/vagrant-libvirt/action/read_ssh_info.rb
@@ -34,7 +34,13 @@ module VagrantPlugins
           ip_address = nil
           domain.wait_for(2) {
             addresses.each_pair do |type, ip|
-              ip_address = ip[0] if ip[0] != nil
+              if ip[0] != nil
+                # Multiple leases are separated with a newline, return only
+                # the most recent address
+                nl_idx = ip[0].index("\n")
+                nl_idx = ip[0].length if nl_idx.nil?
+                ip_address = ip[0][0, nl_idx]
+              end
             end
             ip_address != nil
           }


### PR DESCRIPTION
If DHCP is used as the addressing mode of the VM it may receive various IP
addresses over time.  Thus dnsmasq can report all these addresses for a single
machine, which gives us:

addresses {:public=>["192.168.121.180\n192.168.121.184\n192.168.121.183\n192.168.121.182"],
  :private=>["192.168.121.180\n192.168.121.184\n192.168.121.183\n192.168.121.182"]}

This causes the most problems when NFS is used as the shared folder mechanism,
as the IP addresses pile up and a malformed /etc/exports is written.  This in
turn causes sequences of vagrant halt / vagrant up to receive read-only NFS
exports due to the bad format:

  # VAGRANT-BEGIN: 1000 d943c68a-330b-4cb8-8711-53506a6c176e
  "/home/user/folder" 192.168.121.52
  192.168.121.51(rw,no_subtree_check,all_squash,anonuid=1000,anongid=1000,fsid=3414715164)
  # VAGRANT-END: 1000 d943c68a-330b-4cb8-8711-53506a6c176e

It appears that Vagrant expects that the value returned by read_ssh_info is
just a single IP address, so pick the first IP address reported by dnsmasq.